### PR TITLE
Revert "Bump markdown-it-mark from 3.0.1 to 4.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
                 "markdown-it-anchor": "^9.0.1",
                 "markdown-it-attrs": "^4.1.6",
                 "markdown-it-footnote": "^4.0.0",
-                "markdown-it-mark": "^4.0.0",
+                "markdown-it-mark": "^3.0.1",
                 "markdown-it-mathjax3": "^4.3.1",
                 "markdown-it-plantuml": "^1.4.1",
                 "markdown-it-task-checkbox": "^1.0.6",
@@ -3423,9 +3423,9 @@
             "integrity": "sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ=="
         },
         "node_modules/markdown-it-mark": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-4.0.0.tgz",
-            "integrity": "sha512-YLhzaOsU9THO/cal0lUjfMjrqSMPjjyjChYM7oyj4DnyaXEzA8gnW6cVJeyCrCVeyesrY2PlEdUYJSPFYL4Nkg=="
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-3.0.1.tgz",
+            "integrity": "sha512-HyxjAu6BRsdt6Xcv6TKVQnkz/E70TdGXEFHRYBGLncRE9lBFwDNLVtFojKxjJWgJ+5XxUwLaHXy+2sGBbDn+4A=="
         },
         "node_modules/markdown-it-mathjax3": {
             "version": "4.3.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "markdown-it-anchor": "^9.0.1",
         "markdown-it-attrs": "^4.1.6",
         "markdown-it-footnote": "^4.0.0",
-        "markdown-it-mark": "^4.0.0",
+        "markdown-it-mark": "^3.0.1",
         "markdown-it-mathjax3": "^4.3.1",
         "markdown-it-plantuml": "^1.4.1",
         "markdown-it-task-checkbox": "^1.0.6",


### PR DESCRIPTION
Reverts agniv-the-marker/haskell-garden#3